### PR TITLE
Fix EBADENGINE warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     }
   },
   "engines": {
-    "node": "^9.5.0",
-    "npm": "^5.8.0"
+    "node": ">=9.5.0",
+    "npm": ">=5.8.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.3",


### PR DESCRIPTION
Hi. I get the below warning everytime I use `npm i`. Surprised no one has mentioned it before now. This PR should remove it.

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'jest-text-transformer@1.0.2',
npm WARN EBADENGINE   required: { node: '^9.5.0', npm '^5.8.0' },
npm WARN EBADENGINE   current: { node: 'v16.14.0', npm '8.3.1' },
npm WARN EBADENGINE }
```