### PR TITLE
v27 to v28 migration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,8 @@ module.exports = {
     const escapedSrc = src.replace(/`/g, '\\`')
       .replace(/\$(?=\{.*?\})/g, '\\$')
 
-    return `module.exports = \`${escapedSrc}\``
+    return {
+      code: `module.exports = \`${escapedSrc}\``
+    }
   }
 }


### PR DESCRIPTION
Hi again. Fix for a small breaking change as part of the [v27 to v28 migration](https://jestjs.io/docs/upgrading-to-jest28#transformer).

I tried testing it locally with v27, by manually editing the file in node_modules with the change and I didn't see any problems. So it _shouldn't_ break backwards compatibility, but I can't be certain.