### PR TITLE
Maintenance/upgrade UUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6279,9 +6279,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-to-istanbul": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     }
   },
   "engines": {
-    "node": ">=14.15",
-    "npm": ">=6.14.0"
+    "node": ">=12.13",
+    "npm": ">=6.12.1"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.3",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     }
   },
   "engines": {
-    "node": ">=9.5.0",
-    "npm": ">=5.8.0"
+    "node": ">=14.15",
+    "npm": ">=6.14.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.3",
@@ -49,6 +49,6 @@
     "standard": "^11.0.1"
   },
   "dependencies": {
-    "uuid": "^3.2.1"
+    "uuid": "^9.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const {statSync} = require('fs')
-const uuid = require('uuid/v4')
+const { v4: uuid } = require('uuid')
 
 const cache = {}
 


### PR DESCRIPTION
This upgrades UUID to a more recent version, so that projects using `jest-text-transformer` don't get the 'outdated uuid version' message from NPM or other package managers and security scanners.

Additionally, this commit sets the minimum nodejs version to 12.13, as per jest's v28 minimum requirements.